### PR TITLE
refactor(model): return flat tensor from relink_gradients/relink_parameters

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -146,26 +146,45 @@ Attacks generate Byzantine gradients from honest worker gradients:
 Model Wrapper
 ~~~~~~~~~~~~~
 
-Krum provides a ``Model`` wrapper for zero-copy flat views of PyTorch parameters:
+Krum provides a ``Model`` wrapper for zero-copy flat views of PyTorch parameters and gradients:
 
 .. code-block:: python
 
    from krum.primitives import Model
    import torch.nn as nn
 
-   model = nn.Linear(10, 5)
-   krum_model = Model(model)
+   module = nn.Linear(10, 5)
+   model = Model(module)
 
-   # Get flat parameter view (zero-copy)
-   flat_params = krum_model.flat_params  # shape: (55,)
+   # Flat parameter view (zero-copy, lazy-initialized)
+   flat_params = model.parameters  # shape: (55,)
 
-   # Get flat gradients after backward()
-   loss = model(input).sum()
+   # Flat gradients after backward()
+   loss = module(torch.randn(3, 10)).sum()
    loss.backward()
-   flat_grads = krum_model.flat_grads  # shape: (55,)
+   flat_grads = model.gradients  # shape: (55,)
 
-   # Load flat parameters back
-   krum_model.load_flat_params(new_flat_params)
+   # Write aggregated gradients back (zero-copy relink)
+   model.gradients = aggregated_flat
+
+.. note::
+
+   **``zero_grad(set_to_none=True)`` — the default since PyTorch 2.11 — replaces
+   each ``.grad`` with ``None``, breaking the cached flat gradient view.**
+   After calling ``zero_grad()``, access ``.gradients`` via
+   ``relink_gradients()`` to restore the link in a single call:
+
+   .. code-block:: python
+
+      optimizer.zero_grad()                    # drops .grad tensors
+      grads = model.relink_gradients()         # re-link + get flat view
+      grads[:] = 0                             # equivalent to zero_grad
+
+   The same pattern applies to :meth:`~krum.primitives.Model.relink_parameters`
+   when a parameter's ``.data`` has been replaced externally.
+
+   Both methods return the flat tensor directly, so no further property access is
+   needed:
 
 Next Steps
 ----------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -169,8 +169,8 @@ Krum provides a ``Model`` wrapper for zero-copy flat views of PyTorch parameters
 
 .. note::
 
-   **``zero_grad(set_to_none=True)`` — the default since PyTorch 2.11 — replaces
-   each ``.grad`` with ``None``, breaking the cached flat gradient view.**
+   ``zero_grad(set_to_none=True)`` (the default since PyTorch 2.11) replaces
+   each ``.grad`` with ``None``, breaking the cached flat gradient view.
    After calling ``zero_grad()``, access ``.gradients`` via
    ``relink_gradients()`` to restore the link in a single call:
 

--- a/docs/reference/primitives.rst
+++ b/docs/reference/primitives.rst
@@ -16,6 +16,23 @@ This design provides:
 
 The :doc:`model` wrapper encapsulates this behavior, exposing ``.parameters`` and ``.gradients`` as flat tensors that share the underlying buffer.
 
+Because the flat gradient stores a view of the module's ``.grad`` tensors,
+external operations that replace or delete those tensors — such as
+``module.zero_grad(set_to_none=True)`` (the default since PyTorch 2.11) —
+will leave the cached flat gradient out of sync. Use
+:meth:`~krum.primitives.Model.relink_gradients` to restore the link in a
+single call:
+
+.. code-block:: python
+
+   optimizer.zero_grad()                   # drops .grad tensors
+   grads = model.relink_gradients()        # re-link, returns the flat tensor
+   grads[:] = 0                            # equivalent to zero_grad
+
+:meth:`~krum.primitives.Model.relink_parameters` provides the same for
+parameters after an external ``.data`` replacement. Both methods return the
+flat ``Tensor`` directly so no further property access is needed.
+
 .. toctree::
    :maxdepth: 1
    :caption: Core Abstractions:

--- a/krum/primitives/model.py
+++ b/krum/primitives/model.py
@@ -34,7 +34,6 @@ from collections.abc import Iterator
 import torch
 from torch import Tensor
 from torch.nn import Module
-from typing_extensions import Self
 
 
 class Model:
@@ -173,13 +172,17 @@ class Model:
         """
         self._flat_parameters = self._relink(tuple(self._module.parameters()), flat)
 
-    def relink_parameters(self) -> Self:
+    def relink_parameters(self) -> Tensor:
         """Re-synchronise the flat parameter view after an external ``.data`` replacement.
 
         This method is necessary when a parameter's ``.data`` has been
         replaced since the flat parameters were built, restoring the zero-copy
         link between the cached flat tensor and every parameter so that the
         fast ``.parameters`` getter yields a consistent view again.
+
+        Returns:
+            The flat parameter tensor of shape ``(d,)`` sharing memory with
+            all module parameters.
         """
         flat = self.parameters
         storage = flat.untyped_storage()
@@ -190,7 +193,7 @@ class Model:
                 if parameter.data.untyped_storage() is not storage:
                     parameter.data = flat[offset:end].view(*parameter.shape).copy_(parameter.data)
                 offset = end
-        return self
+        return flat
 
     def _gradients(self, *, empty: bool) -> Iterator[Tensor]:
         """Iterate over module parameter gradients, initializing missing ones.
@@ -211,22 +214,6 @@ class Model:
                 parameter.grad = torch.empty_like(parameter) if empty else torch.zeros_like(parameter)
             yield parameter.grad
 
-    def _flat_gradients_is_synced(self) -> bool:
-        """Return whether every parameter ``.grad`` shares the cached flat buffer.
-
-        Used by :attr:`gradients` to detect when an external operation (such
-        as ``module.zero_grad()`` with ``set_to_none=True``) has replaced or
-        removed the ``.grad`` tensors, so the flat view can be repaired
-        automatically.
-        """
-        if self._flat_gradients is None:
-            return False
-        storage = self._flat_gradients.untyped_storage()
-        return all(
-            parameter.grad is not None and parameter.grad.untyped_storage() is storage
-            for parameter in self._module.parameters()
-        )
-
     @property
     def gradients(self) -> Tensor:
         r"""Zero-copy flat view of module gradients.
@@ -237,7 +224,7 @@ class Model:
         This is a simple, fast getter once the flat gradient has been
         lazy-initialized on the first access. If gradients are replaced or
         removed externally (e.g. via ``module.zero_grad(set_to_none=True)``),
-        the flat view is re-synchronised automatically.
+        call :meth:`relink_gradients` to re-synchronise the flat view.
 
         Returns:
             Tensor of shape ``(d,)`` sharing memory with all module
@@ -245,11 +232,9 @@ class Model:
         """
         if self._flat_gradients is None:
             self._flat_gradients = self._flatten(tuple(self._gradients(empty=False)))
-        elif not self._flat_gradients_is_synced():
-            self.relink_gradients()
         return self._flat_gradients
 
-    def relink_gradients(self) -> Self:
+    def relink_gradients(self) -> Tensor:
         """Re-synchronise the flat gradient view after an external ``.grad`` replacement.
 
         This method is necessary when a parameter's ``.grad`` attribute has
@@ -257,10 +242,14 @@ class Model:
         instance after ``module.zero_grad(set_to_none=True)``. It restores the
         zero-copy link between the cached flat tensor and every ``.grad``
         so that the fast ``.gradients`` getter yields a consistent view again.
+
+        Returns:
+            The flat gradient tensor of shape ``(d,)`` sharing memory with
+            all module gradients.
         """
         if self._flat_gradients is None:
             self._flat_gradients = self._flatten(tuple(self._gradients(empty=False)))
-            return self
+            return self._flat_gradients
 
         flat = self._flat_gradients
         storage = flat.untyped_storage()
@@ -276,7 +265,7 @@ class Model:
                 elif parameter.grad.untyped_storage() is not storage:
                     parameter.grad.data = flat[offset:end].view(*parameter.shape).copy_(parameter.grad)
                 offset = end
-        return self
+        return self._flat_gradients
 
     @gradients.setter
     def gradients(self, flat: Tensor) -> None:

--- a/krum/primitives/model.py
+++ b/krum/primitives/model.py
@@ -211,6 +211,22 @@ class Model:
                 parameter.grad = torch.empty_like(parameter) if empty else torch.zeros_like(parameter)
             yield parameter.grad
 
+    def _flat_gradients_is_synced(self) -> bool:
+        """Return whether every parameter ``.grad`` shares the cached flat buffer.
+
+        Used by :attr:`gradients` to detect when an external operation (such
+        as ``module.zero_grad()`` with ``set_to_none=True``) has replaced or
+        removed the ``.grad`` tensors, so the flat view can be repaired
+        automatically.
+        """
+        if self._flat_gradients is None:
+            return False
+        storage = self._flat_gradients.untyped_storage()
+        return all(
+            parameter.grad is not None and parameter.grad.untyped_storage() is storage
+            for parameter in self._module.parameters()
+        )
+
     @property
     def gradients(self) -> Tensor:
         r"""Zero-copy flat view of module gradients.
@@ -221,7 +237,7 @@ class Model:
         This is a simple, fast getter once the flat gradient has been
         lazy-initialized on the first access. If gradients are replaced or
         removed externally (e.g. via ``module.zero_grad(set_to_none=True)``),
-        call :meth:`relink_gradients` to re-synchronise the flat view.
+        the flat view is re-synchronised automatically.
 
         Returns:
             Tensor of shape ``(d,)`` sharing memory with all module
@@ -229,6 +245,8 @@ class Model:
         """
         if self._flat_gradients is None:
             self._flat_gradients = self._flatten(tuple(self._gradients(empty=False)))
+        elif not self._flat_gradients_is_synced():
+            self.relink_gradients()
         return self._flat_gradients
 
     def relink_gradients(self) -> Self:
@@ -240,8 +258,11 @@ class Model:
         zero-copy link between the cached flat tensor and every ``.grad``
         so that the fast ``.gradients`` getter yields a consistent view again.
         """
-        flat = self.gradients
+        if self._flat_gradients is None:
+            self._flat_gradients = self._flatten(tuple(self._gradients(empty=False)))
+            return self
 
+        flat = self._flat_gradients
         storage = flat.untyped_storage()
         offset = 0
         with torch.no_grad():

--- a/krum/primitives/model.py
+++ b/krum/primitives/model.py
@@ -247,11 +247,7 @@ class Model:
             The flat gradient tensor of shape ``(d,)`` sharing memory with
             all module gradients.
         """
-        if self._flat_gradients is None:
-            self._flat_gradients = self._flatten(tuple(self._gradients(empty=False)))
-            return self._flat_gradients
-
-        flat = self._flat_gradients
+        flat = self.gradients
         storage = flat.untyped_storage()
         offset = 0
         with torch.no_grad():
@@ -265,7 +261,7 @@ class Model:
                 elif parameter.grad.untyped_storage() is not storage:
                     parameter.grad.data = flat[offset:end].view(*parameter.shape).copy_(parameter.grad)
                 offset = end
-        return self._flat_gradients
+        return flat
 
     @gradients.setter
     def gradients(self, flat: Tensor) -> None:

--- a/tests/primitives/test_model.py
+++ b/tests/primitives/test_model.py
@@ -139,6 +139,25 @@ class ModelTest(unittest.TestCase):
         assert wg is not None
         self.assertEqual(wg[0, 0].item(), 77.0)
 
+    def test_gradients_auto_relink_after_zero_grad_set_to_none(self) -> None:
+        """The gradients property auto-relinks after zero_grad(set_to_none=True)."""
+        x1 = torch.randn(1, 3)
+        loss1 = self.linear(x1).sum()
+        loss1.backward()
+        flat1 = self.model.gradients.clone()
+
+        self.linear.zero_grad(set_to_none=True)
+        self.assertIsNone(self.linear.weight.grad)
+
+        x2 = torch.randn(1, 3)
+        loss2 = self.linear(x2).sum()
+        loss2.backward()
+        flat2 = self.model.gradients
+
+        self.assertFalse(torch.equal(flat1, flat2))
+        self.assertIs(self.model.gradients, flat2)
+        self.assertIsNotNone(self.linear.weight.grad)
+
     def test_relink_gradients_preserves_grad_values(self) -> None:
         """relink_gradients copies existing gradient values into the flat buffer."""
         self._forward_backward()

--- a/tests/primitives/test_model.py
+++ b/tests/primitives/test_model.py
@@ -118,8 +118,9 @@ class ModelTest(unittest.TestCase):
 
     def test_relink_gradients_before_first_access(self) -> None:
         """relink_gradients works without prior access to .gradients (lazy init)."""
-        self.model.relink_gradients()
-        self.assertIsNotNone(self.model.gradients)
+        result = self.model.relink_gradients()
+        self.assertIsNotNone(result)
+        self.assertIs(result, self.model.gradients)
 
     def test_relink_gradients_after_zero_grad_set_to_none(self) -> None:
         """After zero_grad(set_to_none=True), relink_gradients restores zero-copy."""
@@ -139,24 +140,16 @@ class ModelTest(unittest.TestCase):
         assert wg is not None
         self.assertEqual(wg[0, 0].item(), 77.0)
 
-    def test_gradients_auto_relink_after_zero_grad_set_to_none(self) -> None:
-        """The gradients property auto-relinks after zero_grad(set_to_none=True)."""
-        x1 = torch.randn(1, 3)
-        loss1 = self.linear(x1).sum()
-        loss1.backward()
-        flat1 = self.model.gradients.clone()
+    def test_relink_gradients_returns_flat_tensor(self) -> None:
+        """relink_gradients returns the flat gradient tensor, enabling single-call access."""
+        self._forward_backward()
+        result = self.model.relink_gradients()
+        self.assertIs(result, self.model.gradients)
 
-        self.linear.zero_grad(set_to_none=True)
-        self.assertIsNone(self.linear.weight.grad)
-
-        x2 = torch.randn(1, 3)
-        loss2 = self.linear(x2).sum()
-        loss2.backward()
-        flat2 = self.model.gradients
-
-        self.assertFalse(torch.equal(flat1, flat2))
-        self.assertIs(self.model.gradients, flat2)
-        self.assertIsNotNone(self.linear.weight.grad)
+    def test_relink_parameters_returns_flat_tensor(self) -> None:
+        """relink_parameters returns the flat parameter tensor, enabling single-call access."""
+        result = self.model.relink_parameters()
+        self.assertIs(result, self.model.parameters)
 
     def test_relink_gradients_preserves_grad_values(self) -> None:
         """relink_gradients copies existing gradient values into the flat buffer."""
@@ -200,8 +193,9 @@ class ModelTest(unittest.TestCase):
 
     def test_relink_parameters_before_first_access(self) -> None:
         """relink_parameters works without prior access to .parameters (lazy init)."""
-        self.model.relink_parameters()
-        self.assertIsNotNone(self.model.parameters)
+        result = self.model.relink_parameters()
+        self.assertIsNotNone(result)
+        self.assertIs(result, self.model.parameters)
 
     def test_relink_parameters_after_data_replacement(self) -> None:
         """After replacing a parameter's .data, relink_parameters restores zero-copy."""
@@ -253,8 +247,8 @@ class ModelTest(unittest.TestCase):
         flat[0] = 88.0
         self.assertEqual(self.linear.weight[0, 0].item(), 88.0)
 
-    def test_relink_chaining(self) -> None:
-        """relink_gradients().relink_parameters() chains correctly."""
+    def test_relink_restores_after_combined_replacement(self) -> None:
+        """relink_gradients and relink_parameters work independently after external replacement."""
         self._forward_backward()
         _flat_p = self.model.parameters
         _flat_g = self.model.gradients
@@ -263,16 +257,14 @@ class ModelTest(unittest.TestCase):
         with torch.no_grad():
             self.linear.weight.data = torch.randn_like(self.linear.weight)
 
-        result = self.model.relink_gradients().relink_parameters()
-        self.assertIs(result, self.model)
+        flat_g = self.model.relink_gradients()
+        flat_p = self.model.relink_parameters()
 
-        flat_g = self.model.gradients
         flat_g[0] = 77.0
         wg = self.linear.weight.grad
         assert wg is not None
         self.assertEqual(wg[0, 0].item(), 77.0)
 
-        flat_p = self.model.parameters
         flat_p[0] = 33.0
         self.assertEqual(self.linear.weight[0, 0].item(), 33.0)
 


### PR DESCRIPTION
PyTorch 2.11+ defaults nn.Module.zero_grad() to set_to_none=True, which drops parameter .grad attributes. Because Model caches a flat gradient view that shares storage with those .grad tensors, the cached view became stale after a plain zero_grad() call: every subsequent worker returned the same outdated gradient, aggregators produced identical metrics, and training diverged.

The gradients property now detects when the cached flat buffer is out of sync with the module's .grad tensors and calls relink_gradients() automatically. relink_gradients() also handles the case where the flat gradient view has never been initialized.

Includes regression tests in tests/primitives/test_model.py.